### PR TITLE
Fix sign in button redirecting to landing page. Resolves #406

### DIFF
--- a/client/controllers/PublicCtrl.js
+++ b/client/controllers/PublicCtrl.js
@@ -1,5 +1,8 @@
 app.controller('PublicCtrl', ['$scope', '$state', function($scope, $state) {
+
   //On Load go to Projects View
-  $state.go('public.landing');
+  if ($state.is('public')) {
+    $state.go('public.landing');
+  }
 
 }]);


### PR DESCRIPTION
Happened only when the page the user clicked 'sign in' on was accessed directly, as opposed to through links in the app.
